### PR TITLE
New Feature: Larger Ender Chest

### DIFF
--- a/src/main/java/de/buuddyyy/buddysystem/BuddySystemPlugin.java
+++ b/src/main/java/de/buuddyyy/buddysystem/BuddySystemPlugin.java
@@ -45,6 +45,7 @@ public final class BuddySystemPlugin extends JavaPlugin {
     private SkipNightHandler skipNightHandler;
     private SpawnHandler spawnHandler;
     private WarpHandler warpHandler;
+    private EnderChestHandler enderChestHandler;
 
     private ProtocolManager protocolManager;
 
@@ -88,14 +89,18 @@ public final class BuddySystemPlugin extends JavaPlugin {
         this.skipNightHandler = new SkipNightHandler(this);
         this.spawnHandler = new SpawnHandler(this);
         this.warpHandler = new WarpHandler(this);
+        this.enderChestHandler = new EnderChestHandler(this);
     }
 
     private void registerEvents() {
         final PluginManager pm = this.getServer().getPluginManager();
         pm.registerEvents(new FoodLevelChangeListener(), this);
+        pm.registerEvents(new InventoryCloseListener(this), this);
+        pm.registerEvents(new InventoryOpenListener(this), this);
         pm.registerEvents(new PlayerBedEnterListener(this), this);
         pm.registerEvents(new PlayerBedLeaveListener(this), this);
         pm.registerEvents(new PlayerChangedWorldListener(this), this);
+        pm.registerEvents(new PlayerInteractListener(this), this);
         pm.registerEvents(new PlayerJoinListener(this), this);
         pm.registerEvents(new PlayerMoveListener(this), this);
         pm.registerEvents(new PlayerQuitListener(this), this);

--- a/src/main/java/de/buuddyyy/buddysystem/commands/EnderChestCommand.java
+++ b/src/main/java/de/buuddyyy/buddysystem/commands/EnderChestCommand.java
@@ -1,6 +1,7 @@
 package de.buuddyyy.buddysystem.commands;
 
 import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import de.buuddyyy.buddysystem.handlers.EnderChestHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -11,9 +12,11 @@ import org.bukkit.inventory.Inventory;
 public class EnderChestCommand implements CommandExecutor {
 
     private final BuddySystemPlugin plugin;
+    private final EnderChestHandler enderChestHandler;
 
     public EnderChestCommand(BuddySystemPlugin plugin) {
         this.plugin = plugin;
+        this.enderChestHandler = plugin.getEnderChestHandler();
     }
 
     @Override
@@ -21,6 +24,7 @@ public class EnderChestCommand implements CommandExecutor {
         if (!(commandSender instanceof Player p)) {
             return false;
         }
+        /*
         if (p.isOp() && args.length == 1) {
             Player targetPlayer;
             if ((targetPlayer = Bukkit.getPlayer(args[0])) == null) {
@@ -36,7 +40,8 @@ public class EnderChestCommand implements CommandExecutor {
             p.openInventory(targetPlayer.getEnderChest());
         } else {
             p.openInventory(p.getEnderChest());
-        }
+        }*/
+        this.enderChestHandler.openEnderChest(p);
         return true;
     }
 

--- a/src/main/java/de/buuddyyy/buddysystem/events/InventoryCloseListener.java
+++ b/src/main/java/de/buuddyyy/buddysystem/events/InventoryCloseListener.java
@@ -1,0 +1,21 @@
+package de.buuddyyy.buddysystem.events;
+
+import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+public class InventoryCloseListener implements Listener {
+
+    private final BuddySystemPlugin plugin;
+
+    public InventoryCloseListener(BuddySystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        this.plugin.getEnderChestHandler().handleInventoryClose(event);
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/events/InventoryOpenListener.java
+++ b/src/main/java/de/buuddyyy/buddysystem/events/InventoryOpenListener.java
@@ -1,0 +1,21 @@
+package de.buuddyyy.buddysystem.events;
+
+import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+
+public class InventoryOpenListener implements Listener {
+
+    private final BuddySystemPlugin plugin;
+
+    public InventoryOpenListener(BuddySystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/events/PlayerInteractListener.java
+++ b/src/main/java/de/buuddyyy/buddysystem/events/PlayerInteractListener.java
@@ -1,0 +1,21 @@
+package de.buuddyyy.buddysystem.events;
+
+import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class PlayerInteractListener implements Listener {
+
+    private final BuddySystemPlugin plugin;
+
+    public PlayerInteractListener(BuddySystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        this.plugin.getEnderChestHandler().handlePlayerInteract(event);
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/events/PlayerJoinListener.java
+++ b/src/main/java/de/buuddyyy/buddysystem/events/PlayerJoinListener.java
@@ -17,7 +17,8 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         final Player p = event.getPlayer();
-        plugin.getPlayerHandler().handleJoin(p);
+        plugin.getPlayerHandler().handlePlayerJoin(p);
+        plugin.getEnderChestHandler().handlePlayerJoin(p);
     }
 
 }

--- a/src/main/java/de/buuddyyy/buddysystem/handlers/EnderChestHandler.java
+++ b/src/main/java/de/buuddyyy/buddysystem/handlers/EnderChestHandler.java
@@ -102,7 +102,7 @@ public class EnderChestHandler {
 
     private boolean canIntegrateEnderChest(Player player) {
         var legacyEnderChest = player.getEnderChest();
-        if (legacyEnderChest.isEmpty()) {
+        if (enderChestManager.hasEnderChest(player.getUniqueId())) {
             return false;
         }
         var inv = Bukkit.createInventory(null, INVENTORY_SIZE);

--- a/src/main/java/de/buuddyyy/buddysystem/handlers/EnderChestHandler.java
+++ b/src/main/java/de/buuddyyy/buddysystem/handlers/EnderChestHandler.java
@@ -1,0 +1,119 @@
+package de.buuddyyy.buddysystem.handlers;
+
+import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import de.buuddyyy.buddysystem.managers.EnderChestManager;
+import de.buuddyyy.buddysystem.sql.entities.EnderChestEntity;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+
+public class EnderChestHandler {
+
+    public static final int INVENTORY_SIZE = 9*6;
+
+    private final BuddySystemPlugin plugin;
+    private final EnderChestManager enderChestManager;
+
+    public EnderChestHandler(BuddySystemPlugin plugin) {
+        this.plugin = plugin;
+        this.enderChestManager = new EnderChestManager(plugin, this.plugin.getDatabaseManager());
+    }
+
+    public void openEnderChest(Player player) {
+        this.openEnderChest(player, player);
+    }
+
+    public void openEnderChest(Player player, Player targetPlayer) {
+        if (!this.enderChestManager.hasEnderChest(targetPlayer.getUniqueId())) {
+            integrateEnderChest(targetPlayer.getPlayer());
+        }
+        var isOwnEnderChest = player.equals(targetPlayer);
+        var invName = isOwnEnderChest ? "Deine EnderChest"
+                : ("EnderChest von " + targetPlayer.getName());
+        var inv = (Inventory) Bukkit.createInventory(null, INVENTORY_SIZE, invName);
+        var ece = this.enderChestManager.getEnderChest(targetPlayer.getUniqueId());
+        var targetInv = ece.getInventory();
+        for (int i = 0; i < targetInv.getSize(); i++) {
+            inv.setItem(i, targetInv.getItem(i));
+        }
+        player.openInventory(inv);
+    }
+
+    public void saveInventory(Player targetPlayer, Inventory inventory) {
+        if (!this.enderChestManager.hasEnderChest(targetPlayer.getUniqueId())) {
+            integrateEnderChest(targetPlayer.getPlayer());
+        }
+        final var newInv = Bukkit.createInventory(null, INVENTORY_SIZE);
+        for (int i = 0; i < inventory.getSize(); i++) {
+            newInv.setItem(i, inventory.getItem(i));
+        }
+        var ece = this.enderChestManager.getEnderChest(targetPlayer.getUniqueId());
+        ece.setInventory(newInv);
+        this.enderChestManager.updateEnderChest(ece);
+    }
+
+    public void handlePlayerJoin(Player player) {
+        if (this.enderChestManager.hasEnderChest(player.getUniqueId()))
+            return;
+        integrateEnderChest(player);
+    }
+
+    public void handlePlayerInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        if (event.getClickedBlock() == null) {
+            return;
+        }
+
+        if (event.getClickedBlock().getType() != Material.ENDER_CHEST) {
+            return;
+        }
+
+        event.setCancelled(true);
+        this.openEnderChest(event.getPlayer());
+    }
+
+    public void handleInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player p)) {
+            return;
+        }
+        final var inv = event.getInventory();
+        if (inv.getHolder() != null)
+            return;
+        var inventoryName = p.getOpenInventory().getTitle();
+        var isOwnEnderChest = "Deine EnderChest".equals(inventoryName);
+        if (isOwnEnderChest) {
+            this.saveInventory(p, inv);
+        }
+    }
+
+    private void integrateEnderChest(Player player) {
+        var integrated = this.canIntegrateEnderChest(player);
+        if (integrated) {
+            System.out.printf("EnderChest from Player %s can be integrated\n", player.getName());
+        }
+    }
+
+    private boolean canIntegrateEnderChest(Player player) {
+        var legacyEnderChest = player.getEnderChest();
+        if (legacyEnderChest.isEmpty()) {
+            return false;
+        }
+        var inv = Bukkit.createInventory(null, INVENTORY_SIZE);
+        for (int i = 0; i < legacyEnderChest.getSize(); i++) {
+            inv.setItem(i, legacyEnderChest.getItem(i));
+        }
+        legacyEnderChest.clear();
+        var pe = this.plugin.getPlayerHandler().getPlayerEntity(player);
+        var entity = new EnderChestEntity(pe, inv);
+        this.enderChestManager.createEnderChest(entity);
+        return true;
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/handlers/PlayerHandler.java
+++ b/src/main/java/de/buuddyyy/buddysystem/handlers/PlayerHandler.java
@@ -3,7 +3,6 @@ package de.buuddyyy.buddysystem.handlers;
 import de.buuddyyy.buddysystem.BuddySystemPlugin;
 import de.buuddyyy.buddysystem.managers.PlayerManager;
 import de.buuddyyy.buddysystem.sql.entities.PlayerEntity;
-import lombok.Getter;
 import org.bukkit.entity.Player;
 
 import java.sql.Timestamp;
@@ -20,7 +19,7 @@ public class PlayerHandler {
         this.playerManager = new PlayerManager(plugin, plugin.getDatabaseManager());
     }
 
-    public void handleJoin(Player player) {
+    public void handlePlayerJoin(Player player) {
         if (!player.hasPlayedBefore()) {
             plugin.getSpawnHandler().teleportPlayerToSpawnImmediately(player);
         }

--- a/src/main/java/de/buuddyyy/buddysystem/managers/EnderChestManager.java
+++ b/src/main/java/de/buuddyyy/buddysystem/managers/EnderChestManager.java
@@ -11,7 +11,6 @@ import de.buuddyyy.buddysystem.sql.entities.PlayerEntity;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 public class EnderChestManager {
 
@@ -34,6 +33,8 @@ public class EnderChestManager {
 
     public void createEnderChest(EnderChestEntity entity) {
         final var uuid = entity.getPlayerEntity().getPlayerUuid();
+        if (hasEnderChest(uuid))
+            return;
         this.databaseManager.insertEntity(entity);
         this.playerEnderChests.refresh(uuid);
     }
@@ -45,15 +46,11 @@ public class EnderChestManager {
     }
 
     public boolean hasEnderChest(UUID uuid) {
-        return this.playerEnderChests.getIfPresent(uuid) != null;
+        return this.getEnderChest(uuid) != null;
     }
 
     public EnderChestEntity getEnderChest(UUID uuid) {
-        try {
-            return this.playerEnderChests.get(uuid);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
-        }
+        return this.playerEnderChests.getIfPresent(uuid);
     }
 
     private EnderChestEntity loadEnderChest(UUID uuid) {

--- a/src/main/java/de/buuddyyy/buddysystem/managers/EnderChestManager.java
+++ b/src/main/java/de/buuddyyy/buddysystem/managers/EnderChestManager.java
@@ -1,0 +1,68 @@
+package de.buuddyyy.buddysystem.managers;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Maps;
+import de.buuddyyy.buddysystem.BuddySystemPlugin;
+import de.buuddyyy.buddysystem.sql.DatabaseManager;
+import de.buuddyyy.buddysystem.sql.entities.EnderChestEntity;
+import de.buuddyyy.buddysystem.sql.entities.PlayerEntity;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+public class EnderChestManager {
+
+    public static final String TABLE_NAME = "player_ender_chests";
+
+    private final LoadingCache<UUID, EnderChestEntity> playerEnderChests;
+    private final BuddySystemPlugin plugin;
+    private final DatabaseManager databaseManager;
+
+    public EnderChestManager(BuddySystemPlugin plugin, DatabaseManager databaseManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+        this.playerEnderChests = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+            @Override
+            public EnderChestEntity load(UUID uuid) {
+                return loadEnderChest(uuid);
+            }
+        });
+    }
+
+    public void createEnderChest(EnderChestEntity entity) {
+        final var uuid = entity.getPlayerEntity().getPlayerUuid();
+        this.databaseManager.insertEntity(entity);
+        this.playerEnderChests.refresh(uuid);
+    }
+
+    public void updateEnderChest(EnderChestEntity entity) {
+        final var uuid = entity.getPlayerEntity().getPlayerUuid();
+        this.databaseManager.updateEntity(entity);
+        this.playerEnderChests.refresh(uuid);
+    }
+
+    public boolean hasEnderChest(UUID uuid) {
+        return this.playerEnderChests.getIfPresent(uuid) != null;
+    }
+
+    public EnderChestEntity getEnderChest(UUID uuid) {
+        try {
+            return this.playerEnderChests.get(uuid);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private EnderChestEntity loadEnderChest(UUID uuid) {
+        final String sql = "SELECT * FROM %s WHERE playerId=:playerId";
+        final Map<String, Object> parameters = Maps.newHashMap();
+        final PlayerEntity pe = plugin.getPlayerHandler().getPlayerEntity(uuid);
+        parameters.put("playerId", pe.getId());
+        return databaseManager.queryResult(EnderChestEntity.class,
+                String.format(sql, TABLE_NAME), parameters);
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/managers/HomeManager.java
+++ b/src/main/java/de/buuddyyy/buddysystem/managers/HomeManager.java
@@ -27,7 +27,7 @@ public class HomeManager {
     public HomeManager(BuddySystemPlugin plugin, DatabaseManager databaseManager) {
         this.plugin = plugin;
         this.databaseManager = databaseManager;
-        this.playerHomes = CacheBuilder.newBuilder().build(new CacheLoader<UUID, HashMap<String, HomeEntity>>() {
+        this.playerHomes = CacheBuilder.newBuilder().build(new CacheLoader<>() {
             @Override
             public HashMap<String, HomeEntity> load(UUID uuid) {
                 return loadAllHomes(uuid);

--- a/src/main/java/de/buuddyyy/buddysystem/sql/DatabaseManager.java
+++ b/src/main/java/de/buuddyyy/buddysystem/sql/DatabaseManager.java
@@ -1,6 +1,7 @@
 package de.buuddyyy.buddysystem.sql;
 
 import de.buuddyyy.buddysystem.configs.MainConfig;
+import de.buuddyyy.buddysystem.sql.entities.EnderChestEntity;
 import de.buuddyyy.buddysystem.sql.entities.HomeEntity;
 import de.buuddyyy.buddysystem.sql.entities.PlayerEntity;
 import de.buuddyyy.buddysystem.sql.entities.WarpEntity;
@@ -50,6 +51,7 @@ public final class DatabaseManager implements AutoCloseable {
         configuration.setProperty("hibernate.format_sql", String.valueOf(formatSql));
         configuration.setProperty("hibernate.hbm2ddl.auto", commandSql);
 
+        configuration.addAnnotatedClass(EnderChestEntity.class);
         configuration.addAnnotatedClass(HomeEntity.class);
         configuration.addAnnotatedClass(PlayerEntity.class);
         configuration.addAnnotatedClass(WarpEntity.class);

--- a/src/main/java/de/buuddyyy/buddysystem/sql/converters/InventoryConverter.java
+++ b/src/main/java/de/buuddyyy/buddysystem/sql/converters/InventoryConverter.java
@@ -1,0 +1,52 @@
+package de.buuddyyy.buddysystem.sql.converters;
+
+import jakarta.persistence.AttributeConverter;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+public class InventoryConverter implements AttributeConverter<Inventory, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Inventory inventory) {
+        try {
+            final var outStream = new ByteArrayOutputStream();
+            final var dataOutput = new BukkitObjectOutputStream(outStream);
+            int size = inventory.getSize();
+            dataOutput.writeInt(size);
+            for (int i = 0; i < size; i++) {
+                dataOutput.writeObject(inventory.getItem(i));
+            }
+            dataOutput.close();
+            return Base64.getEncoder().encodeToString(outStream.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Inventory convertToEntityAttribute(String s) {
+        try {
+            byte[] b = Base64.getDecoder().decode(s);
+            final var inStream = new ByteArrayInputStream(b);
+            final var dataInput = new BukkitObjectInputStream(inStream);
+            int size = dataInput.readInt();
+            var inv = Bukkit.createInventory(null, size);
+            for (int i = 0; i < size; i++) {
+                inv.setItem(i, (ItemStack) dataInput.readObject());
+            }
+            dataInput.close();
+            return inv;
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/de/buuddyyy/buddysystem/sql/entities/EnderChestEntity.java
+++ b/src/main/java/de/buuddyyy/buddysystem/sql/entities/EnderChestEntity.java
@@ -1,0 +1,38 @@
+package de.buuddyyy.buddysystem.sql.entities;
+
+import de.buuddyyy.buddysystem.managers.EnderChestManager;
+import de.buuddyyy.buddysystem.sql.converters.InventoryConverter;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.inventory.Inventory;
+
+@Getter
+@Entity
+@Table(name = EnderChestManager.TABLE_NAME, uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"playerId"})
+})
+public class EnderChestEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @JoinColumn(name = "playerId", referencedColumnName = "id")
+    @ManyToOne(targetEntity = PlayerEntity.class, optional = false)
+    private PlayerEntity playerEntity;
+
+    @Setter
+    @Column(unique = true, columnDefinition = "TEXT")
+    @Convert(converter = InventoryConverter.class)
+    private Inventory inventory;
+
+    public EnderChestEntity(PlayerEntity playerEntity, Inventory inventory) {
+        this.playerEntity = playerEntity;
+        this.inventory = inventory;
+    }
+
+    public EnderChestEntity() {
+    }
+
+}


### PR DESCRIPTION
This feature allows players to have larger Ender Chests (double chest size instead of single chest size). The items of the Ender Chest will be stored in the database. The contents of the normal Ender Chest are transferred to the new Ender Chest without any items being lost.